### PR TITLE
cloud-init-fix

### DIFF
--- a/external-ai-services/cloud-init.yaml
+++ b/external-ai-services/cloud-init.yaml
@@ -8,4 +8,5 @@ users:
 runcmd:
   - export BEARER_TOKEN="YOUR_BEARER_TOKEN"
   - echo $BEARER_TOKEN
+  - export HOME=/root
   - curl -fsSL https://raw.githubusercontent.com/betagouv/VApp/refs/heads/init-instance-ai/external-ai-services/setup-default/setup.sh | sh

--- a/external-ai-services/setup-default/setup.sh
+++ b/external-ai-services/setup-default/setup.sh
@@ -9,36 +9,16 @@ sudo apt install nvidia-cuda-toolkit -y
 # Télécharger et installer ollama
 curl -fsSL https://ollama.com/install.sh | sh
 
-# Créer un service systemd pour Ollama
-sudo tee /etc/systemd/system/ollama.service > /dev/null <<EOL
-[Unit]
-Description=Ollama AI Service
-After=network.target
-
-[Service]
-ExecStart=/usr/local/bin/ollama start
-Restart=always
-User=root
-
-[Install]
-WantedBy=multi-user.target
-EOL
-
-
-sleep 10
-# Activer et démarrer le service Ollama
-sudo systemctl daemon-reload
-sudo systemctl enable ollama.service
-sudo systemctl start ollama.service
-
 sleep 5
 
 # Attendre que Ollama soit prêt (vous pouvez ajuster les délais selon vos besoins)
 echo "Attente de l'initialisation d'Ollama..."
-while ! curl -s http://localhost:11434/health &> /dev/null; do
+while ! ollama --version &> /dev/null; do
     sleep 5
     echo "En attente... Vérifiez si Ollama est prêt."
 done
+
+echo "Ollama est prêt et fonctionne correctement."
 
 # Installer un modèle dans Ollama
 ollama pull llama3.2:1b

--- a/external-ai-services/setup-default/setup.sh
+++ b/external-ai-services/setup-default/setup.sh
@@ -9,16 +9,7 @@ sudo apt install nvidia-cuda-toolkit -y
 # Télécharger et installer ollama
 curl -fsSL https://ollama.com/install.sh | sh
 
-sleep 5
-
-# Attendre que Ollama soit prêt (vous pouvez ajuster les délais selon vos besoins)
-echo "Attente de l'initialisation d'Ollama..."
-while ! ollama --version &> /dev/null; do
-    sleep 5
-    echo "En attente... Vérifiez si Ollama est prêt."
-done
-
-echo "Ollama est prêt et fonctionne correctement."
+sleep 10
 
 # Installer un modèle dans Ollama
 ollama pull llama3.2:1b

--- a/external-ai-services/setup-default/setup.sh
+++ b/external-ai-services/setup-default/setup.sh
@@ -24,10 +24,14 @@ User=root
 WantedBy=multi-user.target
 EOL
 
+
+sleep 10
 # Activer et démarrer le service Ollama
 sudo systemctl daemon-reload
 sudo systemctl enable ollama.service
 sudo systemctl start ollama.service
+
+sleep 5
 
 # Attendre que Ollama soit prêt (vous pouvez ajuster les délais selon vos besoins)
 echo "Attente de l'initialisation d'Ollama..."

--- a/external-ai-services/setup-default/setup.sh
+++ b/external-ai-services/setup-default/setup.sh
@@ -9,7 +9,27 @@ sudo apt install nvidia-cuda-toolkit -y
 # Télécharger et installer ollama
 curl -fsSL https://ollama.com/install.sh | sh
 
-sleep 10
+sudo tee /etc/systemd/system/ollama.service > /dev/null <<EOL
+[Unit]
+Description=Ollama AI Service
+After=network.target
+
+[Service]
+ExecStart=/usr/local/bin/ollama serve
+Restart=always
+User=root
+
+[Install]
+WantedBy=multi-user.target
+EOL
+
+sleep 5
+# Activer et démarrer le service Ollama
+sudo systemctl daemon-reload
+sudo systemctl enable ollama.service
+sudo systemctl start ollama.service
+
+sleep 5
 
 # Installer un modèle dans Ollama
 ollama pull llama3.2:1b


### PR DESCRIPTION
J'ai trouvé une solution à mon problème :

- Assurer un petit délai entre l'installation d'Ollama.
- S'assurer du démarrage de l'application via systemd.
- Exporter la variable d'environnement HOME, qui n'est pas nécessaire dans le setup.sh mais obligatoire en cas d'installation via cloud-init.